### PR TITLE
Sort partitions to comply with spark internal checks

### DIFF
--- a/src/main/scala/com/tresata/spark/kafka/KafkaRDD.scala
+++ b/src/main/scala/com/tresata/spark/kafka/KafkaRDD.scala
@@ -192,7 +192,7 @@ class KafkaRDD private (sc: SparkContext, val topic: String, val offsets: Map[In
     "missing offsets for partition(s) " + (leaders.keySet -- offsets.keySet).toList.sorted.mkString(", ")
   )
 
-  protected def getPartitions: Array[Partition] = leaders.zipWithIndex.map{ case ((partition, leader), index) =>
+  protected def getPartitions: Array[Partition] = leaders.toSeq.sortBy(_._1).zipWithIndex.map{ case ((partition, leader), index) =>
     val (startOffset, stopOffset) = offsets(partition)
     new KafkaPartition(id, index, partition, startOffset, stopOffset, leader)
   }.toArray


### PR DESCRIPTION
See for more details:

https://issues.apache.org/jira/browse/SPARK-13021
https://github.com/apache/spark/commit/32f741115bda5d7d7dbfcd9fe827ecbea7303ffa

Thanks to @ljank for help implementing this fix.

/cc @koertkuipers 